### PR TITLE
[WIP] Update the runtime

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.moddb.TotalChaos.yaml
+++ b/com.moddb.TotalChaos.yaml
@@ -1,6 +1,6 @@
 app-id: com.moddb.TotalChaos
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: gzdoom.sh
 finish-args:
@@ -18,6 +18,27 @@ cleanup:
   - /lib/pkgconfig
   - /share/man
 modules:
+  - shared-modules/gzdoom/gzdoom.json
+
+  - name: fluidsynth
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DLIB_SUFFIX=
+    sources:
+      - type: archive
+        url: https://github.com/FluidSynth/fluidsynth/archive/v2.2.9.tar.gz
+        sha256: bc62494ec2554fdcfc01512a2580f12fc1e1b01ce37a18b370dd7902af7a8159
+
+  - name: freedoom2
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://github.com/freedoom/freedoom/releases/download/v0.12.1/freedoom-0.12.1.zip
+        sha256: f42c6810fc89b0282de1466c2c9c7c9818031a8d556256a6db1b69f6a77b5806
+    build-commands:
+      - install -Dm 644 freedoom2.wad /app/share/games/doom
+
   - name: totalchaos
     buildsystem: simple
     sources:
@@ -31,53 +52,15 @@ modules:
         path: com.moddb.TotalChaos.desktop
       - type: file
         path: com.moddb.TotalChaos.png
+      - type: script
+        commands:
+          - "[ ! -f ~/.config/gzdoom/gzdoom.ini ] && cp /app/share/games/doom/gzdoom_portable.ini ~/.config/gzdoom/gzdoom.ini"
+          - "gzdoom -file totalchaos.pk3 +fluid_patchset /app/share/sounds/sf2/gzdoom.sf2 $@"
+        dest-filename: gzdoom.sh
     build-commands:
       - install -Dm 644 totalchaos.pk3 -t /app/share/games/doom
       - install -Dm 644 gzdoom_portable.ini -t /app/share/games/doom
       - install -Dm 644 com.moddb.TotalChaos.appdata.xml -t /app/share/appdata
       - install -Dm 644 com.moddb.TotalChaos.desktop -t /app/share/applications
       - install -Dm 644 com.moddb.TotalChaos.png -t /app/share/icons/hicolor/128x128/apps
-
-  - name: fluidsynth
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - -DLIB_SUFFIX=
-    sources:
-      - type: archive
-        url: https://github.com/FluidSynth/fluidsynth/archive/v2.0.8.tar.gz
-        sha256: 0c37e72db31d1b35e587b94b7163d68444cffaa9e7fe8a293d79957620bff117
-
-  - name: gzdoom
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - -DSEND_ANON_STATS=OFF
-    sources:
-      - type: archive
-        url: https://github.com/coelckers/gzdoom/archive/g3.6.0.tar.gz
-        sha256: c90912b77f1b545d5a861a71098507328a01e81a697c3a69acf5777579f01dd1
-      - type: patch
-        path: gzdoom-gme-clang-support.patch
-      - type: file
-        url: https://github.com/coelckers/gzdoom/raw/g3.6.0/soundfont/gzdoom.sf2
-        sha256: fca3e514b635a21789d4224e84865d2954a2a914d46b64aa8219ddb565c44869
-      - type: shell
-        commands:
-          - install -Dm 644 gzdoom.sf2 /app/share/sounds/sf2/gzdoom.sf2
-      - type: script
-        commands:
-          - "[ ! -f ~/.config/gzdoom/gzdoom.ini ] && cp /app/share/games/doom/gzdoom_portable.ini ~/.config/gzdoom/gzdoom.ini"
-          - "gzdoom -file totalchaos.pk3 +fluid_patchset /app/share/sounds/sf2/gzdoom.sf2 $@"
-        dest-filename: gzdoom.sh
-    post-install:
       - install -D gzdoom.sh /app/bin/gzdoom.sh
-
-  - name: freedoom2
-    buildsystem: simple
-    sources:
-      - type: archive
-        url: https://github.com/freedoom/freedoom/releases/download/v0.11.3/freedoom-0.11.3.zip
-        sha256: 28a5eafbb1285b78937bd408fcdd8f25f915432340eee79da692eae83bce5e8a
-    build-commands:
-      - install -Dm 644 freedoom2.wad /app/share/games/doom

--- a/com.moddb.TotalChaos.yaml
+++ b/com.moddb.TotalChaos.yaml
@@ -43,7 +43,7 @@ modules:
     buildsystem: simple
     sources:
       - type: archive
-        url: https://www.dropbox.com/sh/93rt8tqpn3i44zp/AAArEDsQrEz5ntHCF2QZz3GLa/totalchaos_dc_b3.zip?dl=1
+        url: https://dl.flathub.org/sources/com.moddb.TotalChaos/totalchaos_dc_b3.zip
         sha256: ff92cfd5dc4f67b1c048e1d493a49de7bd7369543d7b410bd5c10022776a07ae
         dest-filename: totalchaos_dc_b3.zip
       - type: file


### PR DESCRIPTION
- Use GZDoom from shared-modules.
- Update the runtime to 22.08.
- Update dependencies.

Still not ready to be merged. See [this comment](https://github.com/flathub/com.moddb.TotalChaos/pull/11#issuecomment-1260969237).